### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "chapel",
   "language": "Chapel",
-  "repository": "https://github.com/exercism/xchapel",
+  "repository": "https://github.com/exercism/chapel",
   "active": false,
   "test_pattern": "TODO",
   "exercises": [


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1