### PR TITLE
Sync docs with problem-specifications

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.md
+++ b/exercises/practice/hello-world/.docs/instructions.md
@@ -1,10 +1,9 @@
 # Instructions
 
-The classical introductory exercise. Just say "Hello, World!".
+The classical introductory exercise.
+Just say "Hello, World!".
 
-["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
-the traditional first program for beginning programming in a new language
-or environment.
+["Hello, World!"][hello-world] is the traditional first program for beginning programming in a new language or environment.
 
 The objectives are simple:
 
@@ -13,3 +12,5 @@ The objectives are simple:
 - Submit your solution and check it at the website.
 
 If everything goes well, you will be ready to fetch your first real exercise.
+
+[hello-world]: http://en.wikipedia.org/wiki/%22Hello,_world!%22_program

--- a/exercises/practice/two-fer/.docs/instructions.md
+++ b/exercises/practice/two-fer/.docs/instructions.md
@@ -1,6 +1,7 @@
 # Instructions
 
-`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+`Two-fer` or `2-fer` is short for two for one.
+One for you and one for me.
 
 Given a name, return a string with the message:
 


### PR DESCRIPTION
There was a big overhaul in the problem-specifications repository in order to get all the exercise instructions to match the Exercism Markdown Specification in terms of having one line per sentence and using markdown reference links instead of inline links.

This updates the existing implemented exercises.

For future reference I used the command:

    bin/configlet sync --update --yes --docs