### PR TITLE
Follow chapel naming conventions for function names

### DIFF
--- a/exercises/practice/hello-world/test/tests.chpl
+++ b/exercises/practice/hello-world/test/tests.chpl
@@ -2,7 +2,7 @@ use UnitTest;
 
 use HelloWorld;
 
-proc test_hello_world(test : borrowed Test) throws {
+proc testHelloWorld(test : borrowed Test) throws {
   test.assertEqual(hello(), "Hello, World!");
 }
 

--- a/exercises/practice/two-fer/.meta/reference.chpl
+++ b/exercises/practice/two-fer/.meta/reference.chpl
@@ -1,5 +1,5 @@
 module TwoFer {
-  proc two_fer(name : string = "you") {
+  proc twoFer(name : string = "you") {
     return "One for " + name + ", one for me.";
   }
 }

--- a/exercises/practice/two-fer/test/tests.chpl
+++ b/exercises/practice/two-fer/test/tests.chpl
@@ -2,16 +2,16 @@ use UnitTest;
 
 use TwoFer;
 
-proc test_no_name_given(test : borrowed Test) throws {
-  test.assertEqual(two_fer(), "One for you, one for me.");
+proc testNoNameGiven(test : borrowed Test) throws {
+  test.assertEqual(twoFer(), "One for you, one for me.");
 }
 
-proc test_a_name_given(test : borrowed Test) throws {
-  test.assertEqual(two_fer("Alice"), "One for Alice, one for me.");
+proc testANameGiven(test : borrowed Test) throws {
+  test.assertEqual(twoFer("Alice"), "One for Alice, one for me.");
 }
 
-proc test_another_name_given(test : borrowed Test) throws {
-  test.assertEqual(two_fer("Bob"), "One for Bob, one for me.");
+proc testAnotherNameGiven(test : borrowed Test) throws {
+  test.assertEqual(twoFer("Bob"), "One for Bob, one for me.");
 }
 
 UnitTest.main();


### PR DESCRIPTION
I regenerated two fer with the proper naming conventions.

If you decide you would rather have snake case for the test names let me know and I'll tweak the generator back. (It will just take a few seconds, so there's no bother either way).