### PR TITLE
Reformat configs to make configlet happy

### DIFF
--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["lucaferranti"],
+  "authors": [
+    "lucaferranti"
+  ],
   "files": {
-    "solution": ["src/hello-world.chpl"],
-    "test": ["test/tests.chpl"],
-    "example": [".meta/reference.chpl"]
+    "solution": [
+      "src/hello-world.chpl"
+    ],
+    "test": [
+      "test/tests.chpl"
+    ],
+    "example": [
+      ".meta/reference.chpl"
+    ]
   },
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": ["kytrinyx", "lucaferranti"],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/leap.chpl"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": ["kytrinyx", "lucaferranti"],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/resistor-color.chpl"


### PR DESCRIPTION
I forgot that we have tooling to keep formatting of the exercise configs consistent, and I've not run it when I generate the stubs and things.

This reformats the configs by running `bin/configlet fmt --update`