### PR TITLE
Implement stub for raindrops

### DIFF
--- a/config.json
+++ b/config.json
@@ -63,6 +63,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "uuid": "b0317cb6-adaf-4fa7-a050-ad40e1139413",
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/raindrops/.docs/instructions.md
+++ b/exercises/practice/raindrops/.docs/instructions.md
@@ -1,0 +1,20 @@
+# Instructions
+
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors.
+A factor is a number that evenly divides into another number, leaving no remainder.
+The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
+
+The rules of `raindrops` are that if a given number:
+
+- has 3 as a factor, add 'Pling' to the result.
+- has 5 as a factor, add 'Plang' to the result.
+- has 7 as a factor, add 'Plong' to the result.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of the number.
+
+## Examples
+
+- 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
+- 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
+- 34 is not factored by 3, 5, or 7, so the result would be "34".
+
+[modulo]: https://en.wikipedia.org/wiki/Modulo_operation

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": [],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/raindrops.chpl"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "src/raindrops.chpl"
+    ],
+    "test": [
+      "test/tests.chpl"
+    ],
+    "example": [
+      ".meta/reference.chpl"
+    ]
+  },
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
+  "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
+  "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"
+}

--- a/exercises/practice/raindrops/.meta/reference.chpl
+++ b/exercises/practice/raindrops/.meta/reference.chpl
@@ -1,0 +1,3 @@
+module Raindrops {
+  // implement reference solution
+}

--- a/exercises/practice/raindrops/.meta/reference.chpl
+++ b/exercises/practice/raindrops/.meta/reference.chpl
@@ -1,3 +1,10 @@
 module Raindrops {
-  // implement reference solution
+  proc raindrops(num : int) {
+    var drops = "";
+    if num % 3 == 0 then drops += "Pling";
+    if num % 5 == 0 then drops += "Plang";
+    if num % 7 == 0 then drops += "Plong";
+    if drops.isEmpty() then drops = num : string;
+    return drops;
+  }
 }

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/raindrops/Mason.toml
+++ b/exercises/practice/raindrops/Mason.toml
@@ -1,0 +1,5 @@
+[brick]
+name="raindrops"
+version="0.1.0"
+chplVersion="1.28.0"
+type="application"

--- a/exercises/practice/raindrops/src/raindrops.chpl
+++ b/exercises/practice/raindrops/src/raindrops.chpl
@@ -1,0 +1,3 @@
+module Raindrops {
+  // write your solution here
+}

--- a/exercises/practice/raindrops/test/tests.chpl
+++ b/exercises/practice/raindrops/test/tests.chpl
@@ -1,0 +1,77 @@
+use UnitTest;
+
+use Raindrops;
+
+proc testTheSoundFor1Is1(test : borrowed Test) throws {
+  test.assertEqual(convert(1), "1");
+}
+
+proc testTheSoundFor3IsPling(test : borrowed Test) throws {
+  test.assertEqual(convert(3), "Pling");
+}
+
+proc testTheSoundFor5IsPlang(test : borrowed Test) throws {
+  test.assertEqual(convert(5), "Plang");
+}
+
+proc testTheSoundFor7IsPlong(test : borrowed Test) throws {
+  test.assertEqual(convert(7), "Plong");
+}
+
+proc testTheSoundFor6IsPlingAsItHasAFactor3(test : borrowed Test) throws {
+  test.assertEqual(convert(6), "Pling");
+}
+
+proc test2ToThePower3DoesNotMakeARaindropSoundAs3IsTheExponentNotTheBase(test : borrowed Test) throws {
+  test.assertEqual(convert(8), "8");
+}
+
+proc testTheSoundFor9IsPlingAsItHasAFactor3(test : borrowed Test) throws {
+  test.assertEqual(convert(9), "Pling");
+}
+
+proc testTheSoundFor10IsPlangAsItHasAFactor5(test : borrowed Test) throws {
+  test.assertEqual(convert(10), "Plang");
+}
+
+proc testTheSoundFor14IsPlongAsItHasAFactorOf7(test : borrowed Test) throws {
+  test.assertEqual(convert(14), "Plong");
+}
+
+proc testTheSoundFor15IsPlingplangAsItHasFactors3And5(test : borrowed Test) throws {
+  test.assertEqual(convert(15), "PlingPlang");
+}
+
+proc testTheSoundFor21IsPlingplongAsItHasFactors3And7(test : borrowed Test) throws {
+  test.assertEqual(convert(21), "PlingPlong");
+}
+
+proc testTheSoundFor25IsPlangAsItHasAFactor5(test : borrowed Test) throws {
+  test.assertEqual(convert(25), "Plang");
+}
+
+proc testTheSoundFor27IsPlingAsItHasAFactor3(test : borrowed Test) throws {
+  test.assertEqual(convert(27), "Pling");
+}
+
+proc testTheSoundFor35IsPlangplongAsItHasFactors5And7(test : borrowed Test) throws {
+  test.assertEqual(convert(35), "PlangPlong");
+}
+
+proc testTheSoundFor49IsPlongAsItHasAFactor7(test : borrowed Test) throws {
+  test.assertEqual(convert(49), "Plong");
+}
+
+proc testTheSoundFor52Is52(test : borrowed Test) throws {
+  test.assertEqual(convert(52), "52");
+}
+
+proc testTheSoundFor105IsPlingplangplongAsItHasFactors35And7(test : borrowed Test) throws {
+  test.assertEqual(convert(105), "PlingPlangPlong");
+}
+
+proc testTheSoundFor3125IsPlangAsItHasAFactor5(test : borrowed Test) throws {
+  test.assertEqual(convert(3125), "Plang");
+}
+
+UnitTest.main();

--- a/exercises/practice/raindrops/test/tests.chpl
+++ b/exercises/practice/raindrops/test/tests.chpl
@@ -3,75 +3,75 @@ use UnitTest;
 use Raindrops;
 
 proc testTheSoundFor1Is1(test : borrowed Test) throws {
-  test.assertEqual(convert(1), "1");
+  test.assertEqual(raindrops(1), "1");
 }
 
 proc testTheSoundFor3IsPling(test : borrowed Test) throws {
-  test.assertEqual(convert(3), "Pling");
+  test.assertEqual(raindrops(3), "Pling");
 }
 
 proc testTheSoundFor5IsPlang(test : borrowed Test) throws {
-  test.assertEqual(convert(5), "Plang");
+  test.assertEqual(raindrops(5), "Plang");
 }
 
 proc testTheSoundFor7IsPlong(test : borrowed Test) throws {
-  test.assertEqual(convert(7), "Plong");
+  test.assertEqual(raindrops(7), "Plong");
 }
 
 proc testTheSoundFor6IsPlingAsItHasAFactor3(test : borrowed Test) throws {
-  test.assertEqual(convert(6), "Pling");
+  test.assertEqual(raindrops(6), "Pling");
 }
 
 proc test2ToThePower3DoesNotMakeARaindropSoundAs3IsTheExponentNotTheBase(test : borrowed Test) throws {
-  test.assertEqual(convert(8), "8");
+  test.assertEqual(raindrops(8), "8");
 }
 
 proc testTheSoundFor9IsPlingAsItHasAFactor3(test : borrowed Test) throws {
-  test.assertEqual(convert(9), "Pling");
+  test.assertEqual(raindrops(9), "Pling");
 }
 
 proc testTheSoundFor10IsPlangAsItHasAFactor5(test : borrowed Test) throws {
-  test.assertEqual(convert(10), "Plang");
+  test.assertEqual(raindrops(10), "Plang");
 }
 
 proc testTheSoundFor14IsPlongAsItHasAFactorOf7(test : borrowed Test) throws {
-  test.assertEqual(convert(14), "Plong");
+  test.assertEqual(raindrops(14), "Plong");
 }
 
 proc testTheSoundFor15IsPlingplangAsItHasFactors3And5(test : borrowed Test) throws {
-  test.assertEqual(convert(15), "PlingPlang");
+  test.assertEqual(raindrops(15), "PlingPlang");
 }
 
 proc testTheSoundFor21IsPlingplongAsItHasFactors3And7(test : borrowed Test) throws {
-  test.assertEqual(convert(21), "PlingPlong");
+  test.assertEqual(raindrops(21), "PlingPlong");
 }
 
 proc testTheSoundFor25IsPlangAsItHasAFactor5(test : borrowed Test) throws {
-  test.assertEqual(convert(25), "Plang");
+  test.assertEqual(raindrops(25), "Plang");
 }
 
 proc testTheSoundFor27IsPlingAsItHasAFactor3(test : borrowed Test) throws {
-  test.assertEqual(convert(27), "Pling");
+  test.assertEqual(raindrops(27), "Pling");
 }
 
 proc testTheSoundFor35IsPlangplongAsItHasFactors5And7(test : borrowed Test) throws {
-  test.assertEqual(convert(35), "PlangPlong");
+  test.assertEqual(raindrops(35), "PlangPlong");
 }
 
 proc testTheSoundFor49IsPlongAsItHasAFactor7(test : borrowed Test) throws {
-  test.assertEqual(convert(49), "Plong");
+  test.assertEqual(raindrops(49), "Plong");
 }
 
 proc testTheSoundFor52Is52(test : borrowed Test) throws {
-  test.assertEqual(convert(52), "52");
+  test.assertEqual(raindrops(52), "52");
 }
 
 proc testTheSoundFor105IsPlingplangplongAsItHasFactors35And7(test : borrowed Test) throws {
-  test.assertEqual(convert(105), "PlingPlangPlong");
+  test.assertEqual(raindrops(105), "PlingPlangPlong");
 }
 
 proc testTheSoundFor3125IsPlangAsItHasAFactor5(test : borrowed Test) throws {
-  test.assertEqual(convert(3125), "Plang");
+  test.assertEqual(raindrops(3125), "Plang");
 }
 
 UnitTest.main();


### PR DESCRIPTION
At first blush, it seems like the generated test suite might not need any tweaking for this one.

This is the C# solution, in case that helps in terms of getting a reference solution quickly: https://github.com/exercism/csharp/blob/main/exercises/practice/raindrops/.meta/Example.cs