### PR TITLE
update LEARNING.md

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,20 +1,20 @@
 # Learning
 
-This page lists some Chapel learning resources, taken from the [Learning Chapel](https://chapel-lang.org/learning.html) page from the [Chapel website](https://chapel-lang.org/).
+This page lists some Chapel learning resources, taken from the [Learning Chapel][learn-link] page from the [Chapel website][website].
 
 ## Tutorials
 
-- [Chapel tutorials](https://chapel-lang.org/tutorials.html) from the Chapel webpage.
-- [Hands-on exercises](https://chapel-lang.org/handson.html) from the Chapel webpage.
-- [Chapel language primers](https://chapel-lang.org/docs/primers/index.html) from Chapel documentation, introducing the language basics.
-- [Hello World variants](https://chapel-lang.org/docs/examples/index.html) introducing some of Chapel  unique features for parallel and distributed computing.
-- [Introduction to High-Performance Computing in Chapel](http://www.hpc-carpentry.org/hpc-chapel/) from [HPC Carpentry](https://www.hpc-carpentry.org/).
-- [Learn Chapel in Y minutes](https://learnxinyminutes.com/docs/chapel/), a short tour of Chapel syntax.
+- [Chapel tutorials][tutorials-link] from the Chapel webpage.
+- [Hands-on exercises][hands-on-link] from the Chapel webpage.
+- [Chapel language primers][primers-link] from Chapel documentation, introducing the language basics.
+- [Hello World variants][hello-world-link] introducing some of Chapel  unique features for parallel and distributed computing.
+- [Introduction to High-Performance Computing in Chapel][chapel-carpentries-link] from [HPC Carpentry][hpc-carpentry-link].
+- [Learn Chapel in Y minutes][chapel-in-y-minutes-link], a short tour of Chapel syntax.
 
 ## Documentation
 
-- [Chapel documentation](https://chapel-lang.org/docs/)
-- [Chapel syntax cheatsheet](https://chapel-lang.org/docs/language/reference.html)
+- [Chapel documentation][docs-link]
+- [Chapel syntax cheatsheet][cheatsheet-link]
 
 ## Videos
 
@@ -24,4 +24,18 @@ This page lists some Chapel learning resources, taken from the [Learning Chapel]
 
 ## Books
 
--  [Chapel chapter](https://chapel-lang.org/publications/PMfPC-Chapel.pdf) from the [Programming Models for Parallel Computing](https://mitpress.mit.edu/9780262528818/programming-models-for-parallel-computing/) book.
+-  [Chapel chapter][chapter-link] from the [Programming Models for Parallel Computing][book-link] book.
+
+[learn-link]: https://chapel-lang.org/learning.html
+[website]: https://chapel-lang.org/
+[tutorials-link]: https://chapel-lang.org/tutorials.html
+[hands-on-link]: https://chapel-lang.org/handson.html
+[primers-link]: https://chapel-lang.org/docs/primers/index.html
+[hello-world-link]: https://chapel-lang.org/docs/examples/index.html
+[chapel-carpentries-link]: http://www.hpc-carpentry.org/hpc-chapel/
+[hpc-carpentry-link]: https://www.hpc-carpentry.org/
+[chapel-in-y-minutes-link]: https://chapel-lang.org/docs/primers/learnChapelInYMinutes.html
+[docs-link]: https://chapel-lang.org/docs/
+[cheatsheet-link]: https://chapel-lang.org/docs/language/reference.html
+[chapter-link]: https://chapel-lang.org/publications/PMfPC-Chapel.pdf
+[book-link]: https://mitpress.mit.edu/9780262528818/programming-models-for-parallel-computing/


### PR DESCRIPTION
- update link for "Learn Chapel in Y minutes", now it points to the version on the Chapel documentation
- format links (I thought I did this before, but apparently not)
