### PR TITLE
Implement stub for gigasecond

### DIFF
--- a/config.json
+++ b/config.json
@@ -65,6 +65,14 @@
         "difficulty": 1
       },
       {
+        "uuid": "93e093ca-6c17-472c-8acc-75eec4d6e052",
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
         "uuid": "b0317cb6-adaf-4fa7-a050-ad40e1139413",
         "slug": "raindrops",
         "name": "Raindrops",

--- a/exercises/practice/gigasecond/.docs/instructions.md
+++ b/exercises/practice/gigasecond/.docs/instructions.md
@@ -1,0 +1,5 @@
+# Instructions
+
+Given a moment, determine the moment that would be after a gigasecond has passed.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": [],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/gigasecond.chpl"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "src/gigasecond.chpl"
+    ],
+    "test": [
+      "test/tests.chpl"
+    ],
+    "example": [
+      ".meta/reference.chpl"
+    ]
+  },
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
+  "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"
+}

--- a/exercises/practice/gigasecond/.meta/hints.md
+++ b/exercises/practice/gigasecond/.meta/hints.md
@@ -1,0 +1,1 @@
+You may want to check the documentation of the built-in [Time]https://chapel-lang.org/docs/modules/standard/Time.html() module.

--- a/exercises/practice/gigasecond/.meta/reference.chpl
+++ b/exercises/practice/gigasecond/.meta/reference.chpl
@@ -1,0 +1,3 @@
+module Gigasecond {
+  // implement reference solution
+}

--- a/exercises/practice/gigasecond/.meta/reference.chpl
+++ b/exercises/practice/gigasecond/.meta/reference.chpl
@@ -1,3 +1,10 @@
 module Gigasecond {
   // implement reference solution
+  use Time;
+
+  const gigasecond = new timedelta(seconds=1000000000);
+
+  proc addGigasecond(moment: datetime) {
+    return moment + gigasecond;
+  }
 }

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,0 +1,32 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+include = false
+
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+include = false
+
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+include = false
+
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false

--- a/exercises/practice/gigasecond/Mason.toml
+++ b/exercises/practice/gigasecond/Mason.toml
@@ -1,0 +1,5 @@
+[brick]
+name="gigasecond"
+version="0.1.0"
+chplVersion="1.28.0"
+type="application"

--- a/exercises/practice/gigasecond/src/gigasecond.chpl
+++ b/exercises/practice/gigasecond/src/gigasecond.chpl
@@ -1,0 +1,3 @@
+module Gigasecond {
+  // write your solution here
+}

--- a/exercises/practice/gigasecond/test/tests.chpl
+++ b/exercises/practice/gigasecond/test/tests.chpl
@@ -1,0 +1,13 @@
+use UnitTest;
+
+use Gigasecond;
+
+proc testFullTimeSpecified(test : borrowed Test) throws {
+  test.assertEqual(from(new datetime(2015, 01, 24, hour=22, minute=00, second=00)), new datetime(2046, 10, 02, hour=23, minute=46, second=40));
+}
+
+proc testFullTimeWithDayRollOver(test : borrowed Test) throws {
+  test.assertEqual(from(new datetime(2015, 01, 24, hour=23, minute=59, second=59)), new datetime(2046, 10, 03, hour=01, minute=46, second=39));
+}
+
+UnitTest.main();

--- a/exercises/practice/gigasecond/test/tests.chpl
+++ b/exercises/practice/gigasecond/test/tests.chpl
@@ -1,13 +1,17 @@
 use UnitTest;
-
+use Time;
 use Gigasecond;
 
 proc testFullTimeSpecified(test : borrowed Test) throws {
-  test.assertEqual(from(new datetime(2015, 01, 24, hour=22, minute=00, second=00)), new datetime(2046, 10, 02, hour=23, minute=46, second=40));
+  var input    = new datetime(2015, 01, 24, hour=22, minute=00, second=00),
+      expected = new datetime(2046, 10, 02, hour=23, minute=46, second=40);
+  test.assertEqual(addGigasecond(input), expected);
 }
 
 proc testFullTimeWithDayRollOver(test : borrowed Test) throws {
-  test.assertEqual(from(new datetime(2015, 01, 24, hour=23, minute=59, second=59)), new datetime(2046, 10, 03, hour=01, minute=46, second=39));
+  var input    = new datetime(2015, 01, 24, hour=23, minute=59, second=59),
+      expected = new datetime(2046, 10, 03, hour=01, minute=46, second=39);
+  test.assertEqual(addGigasecond(input), expected);
 }
 
 UnitTest.main();


### PR DESCRIPTION
This one is going to need some tweaks to get the test suite looking reasonable.

Once I know what the test suite here should look like I can also generate a stub for the `meetup` problem.

I chose to not implement the first three tests from the canonical data, as they specify only a date rather than a datetime. The tests seem redundant, as we also have a test that specifies the same behavior, but with a datetime as an input.

I also chose not to implement the test for immutability, because from the docs it looks like the datetime functions return new values rather than mutating the existing value. If I'm wrong about that let me know and I'll update this to add the immutability test (I'll need to know how to check for object equality, or whatever the equivalent is called in Chapel).