### PR TITLE
Implement stub for yacht

### DIFF
--- a/config.json
+++ b/config.json
@@ -127,7 +127,16 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
+      },
+      {
+	"uuid": "e2d1d506-2f74-4890-99d0-e8e39c3f3259",
+        "slug": "yacht",
+        "name": "Yacht",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
+
     ]
   },
   "concepts": [],

--- a/exercises/practice/yacht/.docs/instructions.md
+++ b/exercises/practice/yacht/.docs/instructions.md
@@ -1,0 +1,35 @@
+# Instructions
+
+The dice game [Yacht][yacht] is from the same family as Poker Dice, Generala and particularly Yahtzee, of which it is a precursor.
+In the game, five dice are rolled and the result can be entered in any of twelve categories.
+The score of a throw of the dice depends on category chosen.
+
+## Scores in Yacht
+
+| Category | Score | Description | Example |
+| -------- | ----- | ----------- | ------- |
+| Ones | 1 × number of ones | Any combination | 1 1 1 4 5 scores 3 |
+| Twos | 2 × number of twos | Any combination | 2 2 3 4 5 scores 4 |
+| Threes | 3 × number of threes | Any combination | 3 3 3 3 3 scores 15 |
+| Fours | 4 × number of fours | Any combination | 1 2 3 3 5 scores 0 |
+| Fives | 5 × number of fives| Any combination | 5 1 5 2 5 scores 15 |
+| Sixes | 6 × number of sixes | Any combination | 2 3 4 5 6 scores 6 |
+| Full House | Total of the dice | Three of one number and two of another | 3 3 3 5 5 scores 19 |
+| Four of a Kind | Total of the four dice | At least four dice showing the same face | 4 4 4 4 6 scores 16 |
+| Little Straight |  30 points | 1-2-3-4-5 | 1 2 3 4 5 scores 30 |
+| Big Straight | 30 points | 2-3-4-5-6 | 2 3 4 5 6 scores 30 |
+| Choice | Sum of the dice | Any combination | 2 3 3 4 6 scores 18 |
+| Yacht | 50 points | All five dice showing the same face | 4 4 4 4 4 scores 50 |
+
+If the dice do not satisfy the requirements of a category, the score is zero.
+If, for example, *Four Of A Kind* is entered in the *Yacht* category, zero points are scored.
+A *Yacht* scores zero if entered in the *Full House* category.
+
+## Task
+
+Given a list of values for five dice and a category, your solution should return the score of the dice for that category.
+If the dice do not satisfy the requirements of the category your solution should return 0.
+You can assume that five values will always be presented, and the value of each will be between one and six inclusively.
+You should not assume that the dice are ordered.
+
+[yacht]: https://en.wikipedia.org/wiki/Yacht_(dice_game)

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "src/yacht.chpl"
+    ],
+    "test": [
+      "test/tests.chpl"
+    ],
+    "example": [
+      ".meta/reference.chpl"
+    ]
+  },
+  "blurb": "Score a single throw of dice in the game Yacht.",
+  "source": "James Kilfiger, using wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"
+}

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": [],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/yacht.chpl"

--- a/exercises/practice/yacht/.meta/reference.chpl
+++ b/exercises/practice/yacht/.meta/reference.chpl
@@ -1,3 +1,44 @@
 module Yacht {
-  // implement reference solution
+  const name2nums = ["ones" => 1, "twos" => 2, "threes" => 3, "fours" => 4, "fives" => 5, "sixes" => 6];
+
+  proc score(nums: [] int, cat: string) {
+    var sorted = nums.sorted();
+    if name2nums.domain.contains(cat) then return getNumber(sorted, name2nums[cat]);
+    else if cat == "full house" then return getFullHouse(sorted);
+    else if cat == "four of a kind" then return getFourKind(sorted);
+    else if cat == "little straight" then return getLittleStraight(sorted);
+    else if cat == "big straight" then return getBigStraight(sorted);
+    else if cat == "choice" then return getChoice(sorted);
+    else return getYacht(sorted);
+  }
+
+  proc getNumber(vals: [] int, num: int) {
+   return + reduce [v in vals] if v == num then v else 0;
+  }
+
+  proc getFullHouse(nums: [] int) {
+    var twoThree = nums[0] == nums[2] && nums[3] == nums[4] && nums[2] != nums[3],
+        threeTwo = nums[0] == nums[1] && nums[2] == nums[4] && nums[1] != nums[2];
+    return if twoThree || threeTwo then + reduce nums else 0;
+  }
+
+  proc getFourKind(nums: [] int) {
+    return if nums[0] == nums[3] || nums[1] == nums[4] then 4 * nums[1] else 0;
+  }
+
+  proc getLittleStraight(nums: [] int) {
+    return if nums.equals([1, 2, 3, 4, 5]) then 30 else 0;
+  }
+
+  proc getBigStraight(nums: [] int) {
+   return if nums.equals([2, 3, 4, 5, 6]) then 30 else 0;
+  }
+
+  proc getChoice(nums: [] int) {
+    return + reduce nums;
+  }
+
+  proc getYacht(nums: [] int) {
+    return if nums[0] == nums[4] then 50 else 0;
+  }
 }

--- a/exercises/practice/yacht/.meta/reference.chpl
+++ b/exercises/practice/yacht/.meta/reference.chpl
@@ -1,0 +1,3 @@
+module Yacht {
+  // implement reference solution
+}

--- a/exercises/practice/yacht/.meta/tests.toml
+++ b/exercises/practice/yacht/.meta/tests.toml
@@ -1,0 +1,97 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3060e4a5-4063-4deb-a380-a630b43a84b6]
+description = "Yacht"
+
+[15026df2-f567-482f-b4d5-5297d57769d9]
+description = "Not Yacht"
+
+[36b6af0c-ca06-4666-97de-5d31213957a4]
+description = "Ones"
+
+[023a07c8-6c6e-44d0-bc17-efc5e1b8205a]
+description = "Ones, out of order"
+
+[7189afac-cccd-4a74-8182-1cb1f374e496]
+description = "No ones"
+
+[793c4292-dd14-49c4-9707-6d9c56cee725]
+description = "Twos"
+
+[dc41bceb-d0c5-4634-a734-c01b4233a0c6]
+description = "Fours"
+
+[f6125417-5c8a-4bca-bc5b-b4b76d0d28c8]
+description = "Yacht counted as threes"
+
+[464fc809-96ed-46e4-acb8-d44e302e9726]
+description = "Yacht of 3s counted as fives"
+
+[d054227f-3a71-4565-a684-5c7e621ec1e9]
+description = "Fives"
+
+[e8a036e0-9d21-443a-8b5f-e15a9e19a761]
+description = "Sixes"
+
+[51cb26db-6b24-49af-a9ff-12f53b252eea]
+description = "Full house two small, three big"
+
+[1822ca9d-f235-4447-b430-2e8cfc448f0c]
+description = "Full house three small, two big"
+
+[b208a3fc-db2e-4363-a936-9e9a71e69c07]
+description = "Two pair is not a full house"
+
+[b90209c3-5956-445b-8a0b-0ac8b906b1c2]
+description = "Four of a kind is not a full house"
+
+[32a3f4ee-9142-4edf-ba70-6c0f96eb4b0c]
+description = "Yacht is not a full house"
+
+[b286084d-0568-4460-844a-ba79d71d79c6]
+description = "Four of a Kind"
+
+[f25c0c90-5397-4732-9779-b1e9b5f612ca]
+description = "Yacht can be scored as Four of a Kind"
+
+[9f8ef4f0-72bb-401a-a871-cbad39c9cb08]
+description = "Full house is not Four of a Kind"
+
+[b4743c82-1eb8-4a65-98f7-33ad126905cd]
+description = "Little Straight"
+
+[7ac08422-41bf-459c-8187-a38a12d080bc]
+description = "Little Straight as Big Straight"
+
+[97bde8f7-9058-43ea-9de7-0bc3ed6d3002]
+description = "Four in order but not a little straight"
+
+[cef35ff9-9c5e-4fd2-ae95-6e4af5e95a99]
+description = "No pairs but not a little straight"
+
+[fd785ad2-c060-4e45-81c6-ea2bbb781b9d]
+description = "Minimum is 1, maximum is 5, but not a little straight"
+
+[35bd74a6-5cf6-431a-97a3-4f713663f467]
+description = "Big Straight"
+
+[87c67e1e-3e87-4f3a-a9b1-62927822b250]
+description = "Big Straight as little straight"
+
+[c1fa0a3a-40ba-4153-a42d-32bc34d2521e]
+description = "No pairs but not a big straight"
+
+[207e7300-5d10-43e5-afdd-213e3ac8827d]
+description = "Choice"
+
+[b524c0cf-32d2-4b40-8fb3-be3500f3f135]
+description = "Yacht as choice"

--- a/exercises/practice/yacht/Mason.toml
+++ b/exercises/practice/yacht/Mason.toml
@@ -1,0 +1,5 @@
+[brick]
+name="yacht"
+version="0.1.0"
+chplVersion="1.28.0"
+type="application"

--- a/exercises/practice/yacht/src/yacht.chpl
+++ b/exercises/practice/yacht/src/yacht.chpl
@@ -1,0 +1,3 @@
+module Yacht {
+  // write your solution here
+}

--- a/exercises/practice/yacht/test/tests.chpl
+++ b/exercises/practice/yacht/test/tests.chpl
@@ -1,0 +1,121 @@
+use UnitTest;
+
+use Yacht;
+
+proc testYacht(test : borrowed Test) throws {
+  test.assertEqual(score([5, 5, 5, 5, 5], "yacht"), 50);
+}
+
+proc testNotYacht(test : borrowed Test) throws {
+  test.assertEqual(score([1, 3, 3, 2, 5], "yacht"), 0);
+}
+
+proc testOnes(test : borrowed Test) throws {
+  test.assertEqual(score([1, 1, 1, 3, 5], "ones"), 3);
+}
+
+proc testOnesOutOfOrder(test : borrowed Test) throws {
+  test.assertEqual(score([3, 1, 1, 5, 1], "ones"), 3);
+}
+
+proc testNoOnes(test : borrowed Test) throws {
+  test.assertEqual(score([4, 3, 6, 5, 5], "ones"), 0);
+}
+
+proc testTwos(test : borrowed Test) throws {
+  test.assertEqual(score([2, 3, 4, 5, 6], "twos"), 2);
+}
+
+proc testFours(test : borrowed Test) throws {
+  test.assertEqual(score([1, 4, 1, 4, 1], "fours"), 8);
+}
+
+proc testYachtCountedAsThrees(test : borrowed Test) throws {
+  test.assertEqual(score([3, 3, 3, 3, 3], "threes"), 15);
+}
+
+proc testYachtOf3sCountedAsFives(test : borrowed Test) throws {
+  test.assertEqual(score([3, 3, 3, 3, 3], "fives"), 0);
+}
+
+proc testFives(test : borrowed Test) throws {
+  test.assertEqual(score([1, 5, 3, 5, 3], "fives"), 10);
+}
+
+proc testSixes(test : borrowed Test) throws {
+  test.assertEqual(score([2, 3, 4, 5, 6], "sixes"), 6);
+}
+
+proc testFullHouseTwoSmallThreeBig(test : borrowed Test) throws {
+  test.assertEqual(score([2, 2, 4, 4, 4], "full house"), 16);
+}
+
+proc testFullHouseThreeSmallTwoBig(test : borrowed Test) throws {
+  test.assertEqual(score([5, 3, 3, 5, 3], "full house"), 19);
+}
+
+proc testTwoPairIsNotAFullHouse(test : borrowed Test) throws {
+  test.assertEqual(score([2, 2, 4, 4, 5], "full house"), 0);
+}
+
+proc testFourOfAKindIsNotAFullHouse(test : borrowed Test) throws {
+  test.assertEqual(score([1, 4, 4, 4, 4], "full house"), 0);
+}
+
+proc testYachtIsNotAFullHouse(test : borrowed Test) throws {
+  test.assertEqual(score([2, 2, 2, 2, 2], "full house"), 0);
+}
+
+proc testFourOfAKind(test : borrowed Test) throws {
+  test.assertEqual(score([6, 6, 4, 6, 6], "four of a kind"), 24);
+}
+
+proc testYachtCanBeScoredAsFourOfAKind(test : borrowed Test) throws {
+  test.assertEqual(score([3, 3, 3, 3, 3], "four of a kind"), 12);
+}
+
+proc testFullHouseIsNotFourOfAKind(test : borrowed Test) throws {
+  test.assertEqual(score([3, 3, 3, 5, 5], "four of a kind"), 0);
+}
+
+proc testLittleStraight(test : borrowed Test) throws {
+  test.assertEqual(score([3, 5, 4, 1, 2], "little straight"), 30);
+}
+
+proc testLittleStraightAsBigStraight(test : borrowed Test) throws {
+  test.assertEqual(score([1, 2, 3, 4, 5], "big straight"), 0);
+}
+
+proc testFourInOrderButNotALittleStraight(test : borrowed Test) throws {
+  test.assertEqual(score([1, 1, 2, 3, 4], "little straight"), 0);
+}
+
+proc testNoPairsButNotALittleStraight(test : borrowed Test) throws {
+  test.assertEqual(score([1, 2, 3, 4, 6], "little straight"), 0);
+}
+
+proc testMinimumIs1MaximumIs5ButNotALittleStraight(test : borrowed Test) throws {
+  test.assertEqual(score([1, 1, 3, 4, 5], "little straight"), 0);
+}
+
+proc testBigStraight(test : borrowed Test) throws {
+  test.assertEqual(score([4, 6, 2, 5, 3], "big straight"), 30);
+}
+
+proc testBigStraightAsLittleStraight(test : borrowed Test) throws {
+  test.assertEqual(score([6, 5, 4, 3, 2], "little straight"), 0);
+}
+
+proc testNoPairsButNotABigStraight(test : borrowed Test) throws {
+  test.assertEqual(score([6, 5, 4, 3, 1], "big straight"), 0);
+}
+
+proc testChoice(test : borrowed Test) throws {
+  test.assertEqual(score([3, 3, 5, 6, 6], "choice"), 23);
+}
+
+proc testYachtAsChoice(test : borrowed Test) throws {
+  test.assertEqual(score([2, 2, 2, 2, 2], "choice"), 10);
+}
+
+UnitTest.main();


### PR DESCRIPTION
The test suite almost certainly needs to be tweaked for this exercise.

The second argument to the `score` method is a category, which probably needs to be some sort of constant (or something).

Here are some implementations of this exercise in other tracks:
- https://github.com/exercism/csharp/blob/main/exercises/practice/yacht/.meta/Example.cs
- https://github.com/exercism/fsharp/blob/main/exercises/practice/yacht/.meta/Example.fs
- https://github.com/exercism/haskell/blob/main/exercises/practice/yacht/.meta/examples/success-standard/src/Yacht.hs
- https://github.com/exercism/javascript/blob/main/exercises/practice/yacht/.meta/proof.ci.js