### PR TITLE
Implement stub for nucleotide-count

### DIFF
--- a/config.json
+++ b/config.json
@@ -103,6 +103,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "uuid": "6b3c464c-bb34-4667-8dd6-dc9d0c06326c",
+        "slug": "nucleotide-count",
+        "name": "Nucleotide Count",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/nucleotide-count/.docs/instructions.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.md
@@ -1,0 +1,23 @@
+# Instructions
+
+Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed.
+All known life depends on DNA!
+
+> Note: You do not need to understand anything about nucleotides or DNA to complete this exercise.
+
+DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine.
+A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
+We call the order of these nucleotides in a bit of DNA a "DNA sequence".
+
+We represent a DNA sequence as an ordered collection of these four nucleotides and a common way to do that is with a string of characters such as "ATTACG" for a DNA sequence of 6 nucleotides.
+'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' for thymine.
+
+Given a string representing a DNA sequence, count how many of each nucleotide is present.
+If the string contains characters that aren't A, C, G, or T then it is invalid and you should signal an error.
+
+For example:
+
+```text
+"GATTACA" -> 'A': 3, 'C': 1, 'G': 1, 'T': 2
+"INVALID" -> error
+```

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,5 +1,8 @@
 {
-  "authors": [],
+  "authors": [
+    "kytrinyx",
+    "lucaferranti"
+  ],
   "files": {
     "solution": [
       "src/nucleotide-count.chpl"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "src/nucleotide-count.chpl"
+    ],
+    "test": [
+      "test/tests.chpl"
+    ],
+    "example": [
+      ".meta/reference.chpl"
+    ]
+  },
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
+  "source": "The Calculating DNA Nucleotides_problem at Rosalind",
+  "source_url": "http://rosalind.info/problems/dna/"
+}

--- a/exercises/practice/nucleotide-count/.meta/reference.chpl
+++ b/exercises/practice/nucleotide-count/.meta/reference.chpl
@@ -1,0 +1,3 @@
+module NucleotideCount {
+  // implement reference solution
+}

--- a/exercises/practice/nucleotide-count/.meta/reference.chpl
+++ b/exercises/practice/nucleotide-count/.meta/reference.chpl
@@ -1,3 +1,11 @@
 module NucleotideCount {
-  // implement reference solution
+  proc nucleotideCounts(s: string) throws {
+    var D = {"A", "C", "G", "T"};
+    var count: [D] int;
+    for c in s {
+      if D.contains(c) then count[c] += 1;
+      else throw new IllegalArgumentError("Invalid nucleotide in strand"); 
+    }
+    return count;
+  }
 }

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"

--- a/exercises/practice/nucleotide-count/Mason.toml
+++ b/exercises/practice/nucleotide-count/Mason.toml
@@ -1,0 +1,5 @@
+[brick]
+name="nucleotide-count"
+version="0.1.0"
+chplVersion="1.28.0"
+type="application"

--- a/exercises/practice/nucleotide-count/src/nucleotide-count.chpl
+++ b/exercises/practice/nucleotide-count/src/nucleotide-count.chpl
@@ -1,0 +1,3 @@
+module NucleotideCount {
+  // write your solution here
+}

--- a/exercises/practice/nucleotide-count/test/tests.chpl
+++ b/exercises/practice/nucleotide-count/test/tests.chpl
@@ -1,0 +1,30 @@
+use UnitTest;
+
+use NucleotideCount;
+
+proc testEmptyStrand(test : borrowed Test) throws {
+  test.assertEqual(nucleotideCounts(""), [ "A" => 0, "C" => 0, "G" => 0, "T" => 0 ]);
+}
+
+proc testCanCountOneNucleotideInSingleCharacterInput(test : borrowed Test) throws {
+  test.assertEqual(nucleotideCounts("G"), [ "A" => 0, "C" => 0, "G" => 1, "T" => 0 ]);
+}
+
+proc testStrandWithRepeatedNucleotide(test : borrowed Test) throws {
+  test.assertEqual(nucleotideCounts("GGGGGGG"), [ "A" => 0, "C" => 0, "G" => 7, "T" => 0 ]);
+}
+
+proc testStrandWithMultipleNucleotides(test : borrowed Test) throws {
+  test.assertEqual(nucleotideCounts("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"), [ "A" => 20, "C" => 12, "G" => 17, "T" => 21 ]);
+}
+
+proc testStrandWithInvalidNucleotides(test : borrowed Test) throws {
+  try {
+    nucleotideCounts("AGXXACT");
+    throw new owned AssertionError("function was expected to throw an error");
+  } catch e: IllegalArgumentError {
+    test.assertEqual(e.message(), "Invalid nucleotide in strand");
+  }
+}
+
+UnitTest.main();

--- a/exercises/practice/nucleotide-count/test/tests.chpl
+++ b/exercises/practice/nucleotide-count/test/tests.chpl
@@ -21,9 +21,11 @@ proc testStrandWithMultipleNucleotides(test : borrowed Test) throws {
 proc testStrandWithInvalidNucleotides(test : borrowed Test) throws {
   try {
     nucleotideCounts("AGXXACT");
-    throw new owned AssertionError("function was expected to throw an error");
-  } catch e: IllegalArgumentError {
+    throw new AssertionError("Function was expected to throw an error");
+  } catch e : IllegalArgumentError {
     test.assertEqual(e.message(), "Invalid nucleotide in strand");
+  } catch e {
+    throw e;
   }
 }
 

--- a/exercises/practice/nucleotide-count/test/tests.chpl
+++ b/exercises/practice/nucleotide-count/test/tests.chpl
@@ -1,5 +1,5 @@
 use UnitTest;
-
+use UnitTest.TestError;
 use NucleotideCount;
 
 proc testEmptyStrand(test : borrowed Test) throws {

--- a/exercises/practice/nucleotide-count/test/tests.chpl
+++ b/exercises/practice/nucleotide-count/test/tests.chpl
@@ -26,7 +26,8 @@ proc testStrandWithMultipleNucleotides(test : borrowed Test) throws {
 
 proc testStrandWithInvalidNucleotides(test : borrowed Test) throws {
   try {
-    nucleotideCounts("AGXXACT");
+    var strand = "AGXXACT";
+    nucleotideCounts(strand);
     throw new AssertionError("Function was expected to throw an error");
   } catch e : IllegalArgumentError {
     test.assertEqual(e.message(), "Invalid nucleotide in strand");

--- a/exercises/practice/nucleotide-count/test/tests.chpl
+++ b/exercises/practice/nucleotide-count/test/tests.chpl
@@ -1,21 +1,27 @@
 use UnitTest;
-use UnitTest.TestError;
+
 use NucleotideCount;
+use UnitTest.TestError;
+
 
 proc testEmptyStrand(test : borrowed Test) throws {
-  test.assertEqual(nucleotideCounts(""), [ "A" => 0, "C" => 0, "G" => 0, "T" => 0 ]);
+  var strand = "";
+  test.assertEqual(nucleotideCounts(strand), [ "A" => 0, "C" => 0, "G" => 0, "T" => 0 ]);
 }
 
 proc testCanCountOneNucleotideInSingleCharacterInput(test : borrowed Test) throws {
-  test.assertEqual(nucleotideCounts("G"), [ "A" => 0, "C" => 0, "G" => 1, "T" => 0 ]);
+  var strand = "G";
+  test.assertEqual(nucleotideCounts(strand), [ "A" => 0, "C" => 0, "G" => 1, "T" => 0 ]);
 }
 
 proc testStrandWithRepeatedNucleotide(test : borrowed Test) throws {
-  test.assertEqual(nucleotideCounts("GGGGGGG"), [ "A" => 0, "C" => 0, "G" => 7, "T" => 0 ]);
+  var strand = "GGGGGGG";
+  test.assertEqual(nucleotideCounts(strand), [ "A" => 0, "C" => 0, "G" => 7, "T" => 0 ]);
 }
 
 proc testStrandWithMultipleNucleotides(test : borrowed Test) throws {
-  test.assertEqual(nucleotideCounts("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"), [ "A" => 20, "C" => 12, "G" => 17, "T" => 21 ]);
+  var strand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC";
+  test.assertEqual(nucleotideCounts(strand), [ "A" => 20, "C" => 12, "G" => 17, "T" => 21 ]);
 }
 
 proc testStrandWithInvalidNucleotides(test : borrowed Test) throws {


### PR DESCRIPTION
I went with the simplest possible interpretation of how to translate the data from problem-specifications into a chapel test.

Let me know if the template should be tweaked in any way in order to be more idiomatic chapel and I can regenerate the test file.

Here are some reference implementations from other languages:
- https://github.com/exercism/elixir/blob/main/exercises/practice/nucleotide-count/.meta/example.ex
- https://github.com/exercism/go/blob/main/exercises/practice/nucleotide-count/.meta/example.go
- https://github.com/exercism/ruby/blob/main/exercises/practice/nucleotide-count/.meta/example.rb

Closes #15 