### PR TITLE
Implement exercise difference-of-squares

### DIFF
--- a/config.json
+++ b/config.json
@@ -175,6 +175,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 10
+      },
+      {
+       "uuid": "f720055b-312a-44af-b05b-4beaf484ad2e",
+       "slug": "difference-of-squares",
+       "name": "Difference of Squares",
+       "practices": [],
+       "prerequisites": [],
+       "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -1,0 +1,14 @@
+# Instructions
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first ten natural numbers and the sum of the squares of the first ten natural numbers is 3025 - 385 = 2640.
+
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.gitignore
+++ b/exercises/practice/difference-of-squares/.gitignore
@@ -1,0 +1,2 @@
+target/
+Mason.lock

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,0 +1,12 @@
+{
+  "authors": ["lucaferranti"],
+  "contributors": ["kytrinyx"],
+  "files": {
+    "solution": ["src/difference-of-squares.chpl"],
+    "test": ["test/tests.chpl"],
+    "example": [".meta/reference.chpl"]
+  },
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
+  "source": "Problem 6 at Project Euler",
+  "source_url": "https://projecteuler.net/problem=6"
+}

--- a/exercises/practice/difference-of-squares/.meta/reference.chpl
+++ b/exercises/practice/difference-of-squares/.meta/reference.chpl
@@ -1,0 +1,7 @@
+module DifferenceOfSquares {
+  proc sumOfSquares(n) do return + reduce (1..n)**2;
+  
+  proc squareOfSum(n) do return (+ reduce (1..n))**2;
+
+  proc differenceOfSquares(n) do return squareOfSum(n) - sumOfSquares(n);
+}

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/difference-of-squares/Mason.toml
+++ b/exercises/practice/difference-of-squares/Mason.toml
@@ -1,0 +1,8 @@
+[brick]
+name="difference-of-squares"
+version="0.1.0"
+chplVersion="1.33.0"
+type="application"
+
+[dependencies]
+

--- a/exercises/practice/difference-of-squares/src/difference-of-squares.chpl
+++ b/exercises/practice/difference-of-squares/src/difference-of-squares.chpl
@@ -1,0 +1,5 @@
+module DifferenceOfSquares {
+
+// write your solution here 
+
+}

--- a/exercises/practice/difference-of-squares/test/tests.chpl
+++ b/exercises/practice/difference-of-squares/test/tests.chpl
@@ -1,0 +1,25 @@
+use UnitTest;
+use DifferenceOfSquares;
+
+proc test_square_of_sum(test: borrowed Test) throws {
+  test.assertEqual(squareOfSum(0), 0);
+  test.assertEqual(squareOfSum(1), 1);
+  test.assertEqual(squareOfSum(5), 225);
+  test.assertEqual(squareOfSum(100), 25502500);
+}
+
+proc test_sum_of_squares(test: borrowed Test) throws {
+  test.assertEqual(sumOfSquares(0), 0);
+  test.assertEqual(sumOfSquares(1), 1);
+  test.assertEqual(sumOfSquares(5), 55);
+  test.assertEqual(sumOfSquares(100), 338350);
+}
+
+proc test_difference_of_squares(test: borrowed Test) throws {
+  test.assertEqual(differenceOfSquares(0), 0);
+  test.assertEqual(differenceOfSquares(1), 0);
+  test.assertEqual(differenceOfSquares(5), 170);
+  test.assertEqual(differenceOfSquares(100), 25164150);
+}
+
+UnitTest.main();


### PR DESCRIPTION
This adds the stub of the exercise, but is missing the reference solution.

To complete this PR:

- [ ] implement reference solution
- [ ] add yourself to the `authors` array in the exercise config

If you want any tweaks to the test suite, let me know what to change and I'll regenerate it.

